### PR TITLE
Make split-analytics work with the latest split version

### DIFF
--- a/lib/split/analytics.rb
+++ b/lib/split/analytics.rb
@@ -31,10 +31,10 @@ module Split
     end
 
     def custom_variables
-      return nil if session.nil?
+      return nil if ab_user.nil?
       arr = []
 
-      session.each_with_index do |h, i|
+      ab_user.active_experiments.each_with_index do |h, i|
         arr << "_gaq.push([\"_setCustomVar\", #{i + 1}, \"#{h[0]}\", \"#{h[1]}\", 1]);"
       end
       arr.reverse[0..4].reverse.join("\n")

--- a/spec/analytics_spec.rb
+++ b/spec/analytics_spec.rb
@@ -19,8 +19,7 @@ describe Split::Analytics do
 
   it 'should add custom variables for every test the user is involved in' do
     first_alt = ab_test('link_colour', 'red', 'blue')
-
-    expect(session).to eql({'link_colour' => first_alt})
+    expect(ab_user.active_experiments).to eql({'link_colour' => first_alt})
 
     tracking_code = tracking_code(account: 'UA-12345-6')
     expect(tracking_code).to eql(%Q{        <script type=\"text/javascript\">\n          var _gaq = _gaq || [];\n          _gaq.push(["_setAccount", "UA-12345-6"]);\n          \n          _gaq.push(["_setCustomVar", 1, "link_colour", "#{first_alt}", 1]);\n          _gaq.push(["_trackPageview"]);\n          (function() {\n            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;\n            ga.src = ('https:' == document.location.protocol ? 'https://ssl.google-analytics.com/ga.js' : 'http://www.google-analytics.com/ga.js');\n            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);\n          })();\n        </script>\n})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,15 +5,41 @@ require 'split/helper'
 require 'split/analytics'
 require 'ostruct'
 
-def session
-  @ab_user ||= {}
+require "fakeredis"
+
+G_fakeredis = Redis.new
+
+module GlobalSharedContext
+  extend RSpec::SharedContext
+  let(:ab_user){ Split::User.new(double(session: {})) }
+
+  before(:each) do
+    Split.configuration = Split::Configuration.new
+    Split.redis = G_fakeredis
+    Split.redis.flushall
+    @ab_user = ab_user
+    params = nil
+  end
 end
 
 RSpec.configure do |config|
   config.order = 'random'
-  config.before(:each) do
-    Split.configuration = Split::Configuration.new
-    Split.redis.flushall
-    @ab_user = {}
+  config.include GlobalSharedContext
+end
+
+def session
+  @session ||= {}
+end
+
+def params
+  @params ||= {}
+end
+
+def request(ua = 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; de-de) AppleWebKit/533.20.25 (KHTML, like Gecko) Version/5.0.4 Safari/533.20.27')
+  @request ||= begin
+    r = OpenStruct.new
+    r.user_agent = ua
+    r.ip = '192.168.1.1'
+    r
   end
 end

--- a/split-analytics.gemspec
+++ b/split-analytics.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('rspec', '~> 3.1')
   gem.add_development_dependency('rake', '~> 12.3')
+  gem.add_development_dependency('fakeredis', '~> 0.7')
 end

--- a/split-analytics.gemspec
+++ b/split-analytics.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Split::Analytics::VERSION
 
-  gem.add_dependency('split', '>= 1.0.0')
+  gem.add_dependency('split', '>= 3.0.0')
 
   gem.add_development_dependency('rspec', '~> 3.1')
   gem.add_development_dependency('rake', '~> 12.3')


### PR DESCRIPTION
- Upgrade specs configuration to run tests on split
- Use AbUser instead of session to pull active_experiments to Google Analytics

Closes #19 
